### PR TITLE
Add the option to disable the certificate check with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://user-images.githubusercontent.com/13974112/147474213-b4a0cfdb-e7c5-420d-
 - [Plenary.nvim](https://github.com/nvim-lua/plenary.nvim) installed
 - Ensure you have `JENKINS_USER_ID`, `JENKINS_URL`, and also either `JENKINS_API_TOKEN`
     or `JENKINS_PASSWORD` set.
+- Optinally set `JENKINS_INSECURE` to any value to skip the SSL certificate validation (useful for testing)
 
 ## Installation
 

--- a/doc/jenkinsfile-linter.txt
+++ b/doc/jenkinsfile-linter.txt
@@ -34,6 +34,8 @@ PREREQUISITES                            *nvim-jenkinsfile-linter-prerequisites*
   - `JENKINS_USER_ID`
   - `JENKINS_API_TOKEN` or `JENKINS_PASSWORD`
   - `JENKINS_URL`
+- Optionally set JENKINS_INSECURE to any value if your server does not have a
+  proper SSL certificate.
 
 ================================================================================
 

--- a/lua/jenkinsfile_linter.lua
+++ b/lua/jenkinsfile_linter.lua
@@ -6,6 +6,7 @@ local password = os.getenv("JENKINS_PASSWORD")
 local token = os.getenv("JENKINS_API_TOKEN") or os.getenv("JENKINS_TOKEN")
 local jenkins_url = os.getenv("JENKINS_URL") or os.getenv("JENKINS_HOST")
 local namespace_id = vim.api.nvim_create_namespace("jenkinsfile-linter")
+local insecure = os.getenv("JENKINS_INSECURE") and "--insecure" or ""
 local validated_msg = "Jenkinsfile successfully validated."
 local unauthorized_msg = "ERROR 401 Unauthorized"
 local not_found_msg = "ERROR 404 Not Found"
@@ -14,6 +15,7 @@ local function get_crumb_job()
   return Job:new({
     command = "curl",
     args = {
+      insecure,
       "--user",
       user .. ":" .. (token or password),
       jenkins_url .. "/crumbIssuer/api/json",
@@ -35,6 +37,7 @@ local validate_job = vim.schedule_wrap(function(crumb_job)
       :new({
         command = "curl",
         args = {
+          insecure,
           "--user",
           user .. ":" .. (token or password),
           "-X",


### PR DESCRIPTION
Sometimes you have a testing or staging Jenkins deployment that doesn't have a proper SSL certificate. This is a workaround for a case like that. 