### PR TITLE
urlencode Jenkinsfile before sending to validation endpoint

### DIFF
--- a/lua/jenkinsfile_linter.lua
+++ b/lua/jenkinsfile_linter.lua
@@ -23,6 +23,13 @@ local function get_crumb_job()
   })
 end
 
+local function urlencode(text)
+  text = text:gsub("([^A-Za-z0-9%-_.!~*'()])", function (c)
+    return string.format("%%%02X", string.byte(c))
+  end)
+  return text
+end
+
 local validate_job = vim.schedule_wrap(function(crumb_job)
   local concatenated_crumbs = table.concat(crumb_job._stdout_results, " ")
   if string.find(concatenated_crumbs, unauthorized_msg) then
@@ -45,7 +52,7 @@ local validate_job = vim.schedule_wrap(function(crumb_job)
           "-H",
           "Jenkins-Crumb:" .. args.crumb,
           "-d",
-          "jenkinsfile=" .. table.concat(buf_contents, "\n"),
+          "jenkinsfile=" .. urlencode(table.concat(buf_contents, "\n")),
           jenkins_url .. "/pipeline-model-converter/validate",
         },
 

--- a/lua/jenkinsfile_linter.lua
+++ b/lua/jenkinsfile_linter.lua
@@ -24,7 +24,7 @@ local function get_crumb_job()
 end
 
 local function urlencode(text)
-  text = text:gsub("([^A-Za-z0-9%-_.!~*'()])", function (c)
+  text = text:gsub("([^A-Za-z0-9%-_.!~*'()])", function(c)
     return string.format("%%%02X", string.byte(c))
   end)
   return text


### PR DESCRIPTION
The Jenkinsfile contents included in the curl request needs to be URL encoded in order to be validated correctly. Without this, if the pipeline contains any character that happens to have special meaning in URLs, the validation will produce false negative. The minimal example of such situation would be following pipeline:

```groovy
pipeline {
  stages {
    stage('build') {
      steps {
          sh "cd /app/src && npm install"
      }
    }
  }
}
```

The above would produce incorrect error on the "sh" line because & would be interpreted as the end of Jenkinsfile.