### PR TITLE
fix: prevent errors when using secure connections

### DIFF
--- a/lua/jenkinsfile_linter.lua
+++ b/lua/jenkinsfile_linter.lua
@@ -21,6 +21,7 @@ local function get_crumb_job()
   return Job:new({
     command = "curl",
     args = reject_nil({
+      "--silent",
       insecure,
       "--user",
       user .. ":" .. (token or password),
@@ -41,6 +42,7 @@ local validate_job = vim.schedule_wrap(function(crumb_job)
     return Job:new({
       command = "curl",
       args = reject_nil({
+        "--silent",
         insecure,
         "--user",
         user .. ":" .. (token or password),


### PR DESCRIPTION
With my version of curl (`v8.7.1`), if I use a secure jenkins host I get the following error from the job.

This isn't surfaced very well as it the code errors when trying to decode the empty response
https://github.com/ckipp01/nvim-jenkinsfile-linter/blob/b6b48b0a7aed92ed46bb9e1ab208dce92941f50b/lua/jenkinsfile_linter.lua#L33

Job reports the error when logged:
```
[jenkinsfile-linter]   _stderr_results = { "curl: option : blank argument where content is expected" },
...
[jenkinsfile-linter]   args = { "", "--user", "<username>:<token>", "https://<my-secure-jenkins>/crumbIssuer/api/json" },
```

This looks to be coming from the `insecure` parameter which defaults to an empty string when not set via the environment. 

This PR should fix this scenario and report job failures more consistently