### PR TITLE
fix: filter out line in response is empty

### DIFF
--- a/lua/jenkinsfile_linter.lua
+++ b/lua/jenkinsfile_linter.lua
@@ -78,7 +78,10 @@ local validate_job = vim.schedule_wrap(function(crumb_job)
         if data == validated_msg then
           vim.diagnostic.reset(namespace_id, 0)
           vim.notify(validated_msg, vim.log.levels.INFO)
-        else
+        elseif data ~= nil then
+          -- better filter out if the line of response is empty,
+          -- otherwise throw out unexpected error
+          --
           -- We only want to grab the msg, line, and col. We just throw
           -- everything else away. NOTE: That only one seems to ever be
           -- returned so this in theory will only ever match at most once per


### PR DESCRIPTION
I dont know why my jenkins server response an empty line after /pipeline-model-converter/validate, therefore I may this commit for the fix.
example response :
```
Jenkinsfile content '' did not contain the 'pipeline' step

^^^^  here is cause nil in line 91, which nil can't pass to regex 
```